### PR TITLE
feat(state): ensure mines are placed when entering Playing

### DIFF
--- a/include/Minefields/States.h
+++ b/include/Minefields/States.h
@@ -15,6 +15,9 @@ struct State
 State stateMainMenuUpdate(GameContext& context);
 State stateOptionsUpdate(GameContext& context);
 State stateQuitUpdate(GameContext& context);
+State statePlayingUpdate(GameContext& context);
+State stateWonUpdate(GameContext& context);
+State stateLostUpdate(GameContext& context);
 
 void runMainLoop();
 void clearConsoleBuffer();

--- a/src/Minefields/Game.cpp
+++ b/src/Minefields/Game.cpp
@@ -97,38 +97,7 @@ void placeCpuMines(std::vector<std::vector<Cell>>& board, int mineCount, CoordGe
         }
     }
 }
-void playTurns(int height, int width, int totalMines, CoordGenerator const& generateCoord)
-{
-    int playerMinesLeft = totalMines;
-    int cpuMinesLeft = totalMines;
 
-    Board gameBoard(width, height);
-    auto& board = gameBoard.grid;
-
-    placePlayerMines(board, playerMinesLeft);
-    placeCpuMines(board, cpuMinesLeft, generateCoord);
-
-    while (playerMinesLeft > 0 && cpuMinesLeft > 0)
-    {
-        std::cout << "\n===== NEW ROUND =====\n";
-
-        std::vector<std::vector<bool>> matrix(height, std::vector<bool>(width, false));
-
-        std::cout << "\n--- Player's turn ---\n";
-        playerTurn(board, matrix, width, height, playerMinesLeft, cpuMinesLeft);
-
-        if (cpuMinesLeft <= 0)
-        {
-            break;
-        }
-
-        std::cout << "\n--- CPU's turn ---\n";
-        cpuTurn(board, matrix, width, height, playerMinesLeft, cpuMinesLeft, generateCoord);
-
-        printBoard(board);
-        std::cout << "\nMines left - Player: " << playerMinesLeft << ", CPU: " << cpuMinesLeft << "\n";
-    }
-}
 void playerTurn(std::vector<std::vector<Cell>>& board, std::vector<std::vector<bool>>& matrix, int width, int height, int& playerMinesLeft, int& cpuMinesLeft)
 {
     bool validInput = false;

--- a/src/Minefields/States.cpp
+++ b/src/Minefields/States.cpp
@@ -4,6 +4,12 @@
 #include <iostream>
 namespace Minefields
 {
+static constexpr int kNoMinesLeft = 0;
+static unsigned int const kOption1 = 1;
+static unsigned int const kOption2 = 2;
+static unsigned int const kOption3 = 3;
+
+
 void clearConsoleBuffer();
 
 void clearConsoleBuffer()
@@ -19,11 +25,63 @@ State stateQuitUpdate(GameContext& context)
     return {nullptr};
 }
 
+State statePlayingUpdate(GameContext& context)
+{
+    std::vector<std::vector<bool>> matrix(context.height, std::vector<bool>(context.width, false));
+
+    std::cout << "\n===== NEW ROUND =====\n";
+
+    std::cout << "\n--- Player's turn ---\n";
+
+    playerTurn(context.board.grid, matrix, context.width, context.height, context.playerMinesLeft, context.cpuMinesLeft);
+
+    if (context.cpuMinesLeft <= kNoMinesLeft)
+    {
+        return {&stateWonUpdate};
+    }
+
+    std::cout << "\n--- CPU's turn ---\n";
+    cpuTurn(context.board.grid, matrix, context.width, context.height, context.playerMinesLeft, context.cpuMinesLeft, context.generateCoord);
+
+    printBoard(context.board.grid);
+    std::cout << "\nMines left - Player: " << context.playerMinesLeft << ", CPU: " << context.cpuMinesLeft << "\n";
+
+    if (context.playerMinesLeft <= kNoMinesLeft)
+    {
+        return {&stateLostUpdate};
+    }
+
+    return {&statePlayingUpdate};
+}
+
+State stateWonUpdate(GameContext& context)
+{
+    std::cout << "CPU has no mines left. You win!\n";
+    return {nullptr};
+}
+
+State stateLostUpdate(GameContext& context)
+{
+    std::cout << "You have no mines left. CPU wins!\n";
+    return {nullptr};
+}
+
 State stateOptionsUpdate(GameContext& context)
 {
     std::cout << "Inside options\n";
 
-    return context.currentState;
+    std::cout << "1) Back to menu\n2) Quit\n> ";
+
+    int sel = 0;
+
+    std::cin >> sel;
+
+    if (sel == kOption2)
+    {
+        return {&stateQuitUpdate};
+    }
+
+    return {&stateMainMenuUpdate};
 }
 
 State stateMainMenuUpdate(GameContext& context)
@@ -40,20 +98,22 @@ State stateMainMenuUpdate(GameContext& context)
     std::cout << "Inside main menu\n";
 
     int userSelection = 0;
-    static unsigned int const Option1 = 1;
-    static unsigned int const Option2 = 2;
 
-    std::cout << "Welcome to Game! Select an option to continue:\n1. Options\n2. Quit\n> ";
+    std::cout << "Welcome to Game! Select an option to continue:\n1. Options\n2. Quit\n3. Play\n> ";
     std::cin >> userSelection;
-    if (userSelection == Option1)
+    if (userSelection == kOption1)
     {
         std::cout << "MainMenu: User selected options\n";
         return {&stateOptionsUpdate};
     }
-    else if (userSelection == Option2)
+    if (userSelection == kOption2)
     {
         std::cout << "MainMenu: User selected quit\n";
         return {&stateQuitUpdate};
+    }
+    else if (userSelection == kOption3)
+    {
+        return {&statePlayingUpdate};
     }
 
     std::cout << "MainMenu: User did not select anything\n";
@@ -74,6 +134,4 @@ void runMainLoop()
         quit = context.currentState.updateFunction == nullptr;
     }
 }
-	
-	
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,19 +2,21 @@
 #include <Minefields/Utils.h>
 #include <Minefields/Game.h>
 #include <Minefields/Player.h>
+#include <Minefields/States.h>
 
 int main() 
 {
     int height = 0;
     int width = 0;
-    inputBoardSize(height, width);
+    //inputBoardSize(height, width);
 
     Player player;
-    int totalMines = inputMines(player);
+    //int totalMines = inputMines(player);
 
     CoordGenerator generateCoord = std::bind(generateRandomCoord, width, height);
 
-    playTurns(height, width, totalMines, generateCoord);
+    Minefields::runMainLoop();
+   // playTurns(height, width, totalMines, generateCoord);
 
     return 0;
 }


### PR DESCRIPTION
Added a setup check at the beginning of statePlayingUpdate.
If the Board is empty, the state now:
Creates the Board with the configured width/height.
Resets attempted shots.
Calls placePlayerMines o let the player place mines.
Calls placeCpuMines to place CPU mines.
This prevents the game from immediately ending when entering Playing without mines.